### PR TITLE
Use Todoist's Sync API v9 and pass token as header

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const PREMIUM = core.getInput("PREMIUM");
 
 async function main() {
   const stats = await axios(
-    `https://api.todoist.com/sync/v8.3/completed/get_stats?token=${TODOIST_API_KEY}`
+    `https://api.todoist.com/sync/v9/completed/get_stats?token=${TODOIST_API_KEY}`
   );
   await updateReadme(stats.data);
 }

--- a/index.js
+++ b/index.js
@@ -8,8 +8,9 @@ const TODOIST_API_KEY = core.getInput("TODOIST_API_KEY");
 const PREMIUM = core.getInput("PREMIUM");
 
 async function main() {
-  const stats = await axios(
-    `https://api.todoist.com/sync/v9/completed/get_stats?token=${TODOIST_API_KEY}`
+  const stats = await axios.get(
+    "https://api.todoist.com/sync/v9/completed/get_stats",
+    { headers: { Authorization: `Bearer ${TODOIST_API_KEY}` } }
   );
   await updateReadme(stats.data);
 }


### PR DESCRIPTION
v8 was deprecated on December 5, 2022, and passing tokens as query parameters will stop working soon.

I didn't notice any other incompatibility, but here's the migration guide from v8: https://developer.todoist.com/sync/v9/#migrating-from-v8